### PR TITLE
Add classes to use every type of mysql::server::

### DIFF
--- a/manifests/mysql/huge.pp
+++ b/manifests/mysql/huge.pp
@@ -1,0 +1,8 @@
+#
+# == Class: pacemaker::mysql::huge
+#
+# Use a huge mysql server with pacemaker
+#
+class pacemaker::mysql::huge inherits mysql::server::huge {
+  include pacemaker::mysql::base
+}

--- a/manifests/mysql/large.pp
+++ b/manifests/mysql/large.pp
@@ -1,0 +1,8 @@
+#
+# == Class: pacemaker::mysql::large
+#
+# Use a large mysql server with pacemaker
+#
+class pacemaker::mysql::large inherits mysql::server::large {
+  include pacemaker::mysql::base
+}

--- a/manifests/mysql/medium.pp
+++ b/manifests/mysql/medium.pp
@@ -1,0 +1,8 @@
+#
+# == Class: pacemaker::mysql::medium
+#
+# Use a medium mysql server with pacemaker
+#
+class pacemaker::mysql::medium inherits mysql::server::medium {
+  include pacemaker::mysql::base
+}

--- a/manifests/mysql/small.pp
+++ b/manifests/mysql/small.pp
@@ -1,0 +1,8 @@
+#
+# == Class: pacemaker::mysql::small
+#
+# Use a small mysql server with pacemaker
+#
+class pacemaker::mysql::small inherits mysql::server::small {
+  include pacemaker::mysql::base
+}

--- a/manifests/mysql/unmanaged.pp
+++ b/manifests/mysql/unmanaged.pp
@@ -1,0 +1,8 @@
+#
+# == Class: pacemaker::mysql::unmanaged
+#
+# Use a unmanaged mysql server with pacemaker
+#
+class pacemaker::mysql::unmanaged inherits mysql::server::unmanaged {
+  include pacemaker::mysql::base
+}


### PR DESCRIPTION
Add classes to use every type ou mysql::server::\* we defined in our mysql module, so we can use every of them with this module.
