### PR TITLE
pacemaker::postgresql: this inheritance makes no sense in this context

### DIFF
--- a/manifests/postgresql.pp
+++ b/manifests/postgresql.pp
@@ -13,7 +13,7 @@ Example usage:
   include pacemaker::postgresql
 
 */
-class pacemaker::postgresql inherits postgresql::base {
+class pacemaker::postgresql {
 
   case $operatingsystem {
 


### PR DESCRIPTION
The best way is simply to include the class 'postgresql' before including
this class. In parallel in the postgresql module, we need to add the
possibility of not managing the service (I will make a patch for this).
