### PR TITLE
Add logrotate configuration

### DIFF
--- a/manifests/corosync.pp
+++ b/manifests/corosync.pp
@@ -1,3 +1,7 @@
+#
+# == Class: pacemaker::corosync
+#
+# $pacemaker_log_time_unit: a valid value for logrotate: daily, monthly, weekly
 class pacemaker::corosync {
   # TODO: put this variables in pacemaker::corosync:params
 
@@ -13,6 +17,15 @@ class pacemaker::corosync {
   if ( ! $pacemaker_warntime )  { $pacemaker_warntime = "6" }
   if ( ! $pacemaker_deadtime )  { $pacemaker_deadtime = "10" }
   if ( ! $pacemaker_initdead )  { $pacemaker_initdead = "15" }
+
+  # For logrotate configuration
+   if ( ! $pacemaker_logrotate_template ) { $pacemaker_logrotate_template = 'pacemaker/corosync.logrotate.erb' }
+   if ( ! $pacemaker_log_units_hold )  { $pacemaker_log_units_hold = '32' }
+
+  $pacemaker_log_time_unit = $pacemaker_log_time_unit ? {
+    /daily|weekly|monthly/ => $pacemaker_log_time_unit,
+    default => 'daily',
+  }
 
   case $operatingsystem {
     RedHat: {
@@ -111,6 +124,14 @@ class pacemaker::corosync {
     mode    => 0400,
     source  => $corosync_authkey_file,
     require => Package["corosync"],
+  }
+
+  file { '/etc/logrotate.d/corosync':
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    content => template( $pacemaker_logrotate_template ),
+    replace => false,
   }
 
   service { "corosync":

--- a/templates/corosync.logrotate.erb
+++ b/templates/corosync.logrotate.erb
@@ -1,0 +1,9 @@
+# file installed but NOT managed by Puppet
+/var/log/corosync.log {
+  missingok
+  nocompress
+  notifempty
+  <%= pacemaker_log_time_unit %>
+  rotate <%= pacemaker_log_units_hold %>
+  copytruncate
+}


### PR DESCRIPTION
Add a configuration file for logrotate.
Don't overwrite an existing file, just install a default one.
This default configuration provided don't need to restart/reload the service, as it use the "copytruncate" parameter.
Some lines can be lost with this, but I think this is acceptable, better than a restart.
