### PR TITLE
Use class parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,50 +1,55 @@
-/*
-
-== Class: pacemaker
-
-Installs the pacemaker package and heartbeat high availability service. This
-class sets up heartbeat on the nodes of the cluster, then optionally loads the
-cluster configuration.
-
-The default communication between nodes is via network broadcast. So mind your
-network and firewall settings !
-
-Once you have included this class, you should be able to see in the system logs
-that the cluster nodes are talking to each other. "crm status" should display all
-your cluster nodes as "online".
-
-It is then your job to define the cluster resources and relationships using the
-"crm" command. For more details, see http://clusterlabs.org/wiki/Documentation
-
-
-Class variables:
-- *$pacemaker_authkey*: the secret key shared between cluster nodes. It is
-  required to set this attribute.
-- *$pacemaker_crmcli*: the configuration file we want to activate as a
-  configuration file. If this attribute is not set, puppet will not manage the
-  cluster's configuration.
-- *$pacemaker_hacf*: An alternate file to use instead of the default
-  /etc/ha.d/ha.cf defined in this class. This attribute should point to an ERB
-  template somewhere in your modulepath.
-- *$pacemaker_port*: UDP port used in default configuration. Defaults to 691.
-- *$pacemaker_interface*: Interface used in default configuration. Defaults to eth0.
-- *$pacemaker_keepalive*: keepalive parameter used in default configuration. Defaults to 1.
-- *$pacemaker_warntime*: warntime parameter used in default configuration. Defaults to 6.
-- *$pacemaker_deadtime*: deadtime parameter used in default configuration. Defaults to 10.
-- *$pacemaker_initdead*: initdead parameter used in default configuration. Defaults to 15.
-
-
-Example usage:
-
-  # use ha.cf template from $moduledir/mymodule/templates/myproject.ha.cf.erb
-  $pacemaker_hacf      = "mymodule/myproject.ha.cf.erb"
-  $pacemaker_crmcli    = "puppet:///modules/myproject/crm_config.cli"
-  $pacemaker_interface = "eth1"
-  $pacemaker_authkey   = "gugus"
-
-  include pacemaker
-
-*/
+#
+# == Class: pacemaker
+#
+# Installs the pacemaker package and heartbeat high availability service. This
+# class sets up heartbeat on the nodes of the cluster, then optionally loads the
+# cluster configuration.
+#
+# The default communication between nodes is via network broadcast. So mind your
+# network and firewall settings !
+#
+# Once you have included this class, you should be able to see in the system logs
+# that the cluster nodes are talking to each other. "crm status" should display all
+# your cluster nodes as "online".
+#
+# It is then your job to define the cluster resources and relationships using the
+# "crm" command. For more details, see http://clusterlabs.org/wiki/Documentation
+#
+#
+# Class variables:
+# - *$pacemaker_authkey*: the secret key shared between cluster nodes. It is
+#   required to set this attribute.
+# - *$pacemaker_crmcli*: the configuration file we want to activate as a
+#   configuration file. If this attribute is not set, puppet will not manage the
+#   cluster's configuration.
+# - *$pacemaker_hacf*: An alternate file to use instead of the default
+#   /etc/ha.d/ha.cf defined in this class. This attribute should point to an ERB
+#   template somewhere in your modulepath.
+# - *$pacemaker_port*: UDP port used in default configuration. Defaults to 691.
+# - *$pacemaker_interface*: Interface used in default configuration. Defaults to eth0.
+# - *$pacemaker_keepalive*: keepalive parameter used in default configuration. Defaults to 1.
+# - *$pacemaker_warntime*: warntime parameter used in default configuration. Defaults to 6.
+# - *$pacemaker_deadtime*: deadtime parameter used in default configuration. Defaults to 10.
+# - *$pacemaker_initdead*: initdead parameter used in default configuration. Defaults to 15.
+#
+#
+# # Example usage:
+#
+#  # use ha.cf template from $moduledir/mymodule/templates/myproject.ha.cf.erb
+#
+#  include pacemaker
+#
+#  class{ 'pacemaker':
+#    pacemaker_authkey   => 'TheAuthKey',
+#    pacemaker_nodes     => [$host1, $host2],
+#    pacemaker_interface => 'eth1',
+#    pacemaker_deadtime  => 60,
+#    pacemaker_initdead  => 60,
+#    pacemaker_warntime  => 30,
+#    pacemaker_ping      => '0.0.0.0',
+#    pacemaker_hacf      => 'mymodule/myproject.ha.cf.erb'
+#  }
+#
 class pacemaker(
   $pacemaker_authkey,
   $pacemaker_nodes,


### PR DESCRIPTION
Use class paremeter in order to be useable with puppet3.
It breaks backward compatiblity, but this module isn't the most popular of ours, and we plan to use the one from puppetlabs.
