### PR TITLE
Fix crm facts

### DIFF
--- a/lib/facter/crm.rb
+++ b/lib/facter/crm.rb
@@ -16,37 +16,34 @@ Facter.add('crm_support') do
   end
 end
 
-crm_resources = []
+if Facter.value(:crm_support) == true
+  crm_resources = Facterclass.exec('crm_resource -l').split
 
-Facter.add('crm_raw_resources') do
-  confine :crm_support => true
-
-  resources = Facterclass.exec('crm_resource -l')
-  unless resources.empty?
-    crm_resources = resources.split
+  Facter.add('crm_raw_resources') do
+    confine :false => crm_resources.empty?
     setcode { crm_resources.join(',') }
   end
-end
-
-crm_resources.each do |resource|
-  command = "crm_resource --resource #{resource} --locate"
-  crm_output = Facterclass.exec(command)
-  location = /^resource #{resource} is running on: (.+?)\s?\w*$/.match(crm_output).nil? ? '' : Regexp.last_match[1]
-  next if location.empty?
   
-  if resource =~ /^\w+:(0|1)$/ # Master/Slave resources
-    _resource = resource.split(':')[0]
-    if crm_output =~ /^.*\sMaster$/
-      fact_name = "crm_#{_resource}_master"
+  crm_resources.each do |resource|
+    command = "crm_resource --resource #{resource} --locate"
+    crm_output = Facterclass.exec(command)
+    location = /^resource #{resource} is running on: (.+?)\s?\w*$/.match(crm_output).nil? ? '' : Regexp.last_match[1]
+    next if location.empty?
+
+    if resource =~ /^\w+:(0|1)$/ # Master/Slave resources
+      _resource = resource.split(':')[0]
+      if crm_output =~ /^.*\sMaster$/
+        fact_name = "crm_#{_resource}_master"
+      else
+        fact_name = "crm_#{_resource}_slave"
+      end
     else
-      fact_name = "crm_#{_resource}_slave"
+      fact_name = "crm_#{resource}"
     end
-  else
-    fact_name = "crm_#{resource}"
+
+    Facter.add(fact_name) do
+      setcode { location }
+    end
   end
 
-  Facter.add(fact_name) do
-    confine :crm_support => true
-    setcode { location }
-  end
 end


### PR DESCRIPTION
Avoid a runtime error when crm_support is false. The `confine`
only acts on the `setcode` block so it was not being used properly.